### PR TITLE
Add basic gateway support

### DIFF
--- a/src/aurora/client/main.cc
+++ b/src/aurora/client/main.cc
@@ -20,7 +20,9 @@ int main(int argc, char** argv) {
   boost::asio::ssl::context ssl{boost::asio::ssl::context::tlsv13_client};
 
   std::string host = "gateway.discord.gg";
-  std::make_shared<aurora::gateway::Session>(ctx, ssl)->Connect(host);
+  std::shared_ptr<aurora::gateway::Session> session = std::make_shared<aurora::gateway::Session>(ctx, ssl);
+  session->SubscribeTo(GUILDS | GUILD_MESSAGES);
+  session->Connect(getenv("AURORA_TOKEN"), host);
 
   ctx.run();
 

--- a/src/aurora/gateway/CMakeLists.txt
+++ b/src/aurora/gateway/CMakeLists.txt
@@ -9,10 +9,10 @@ target_sources(AuroraGateway
     PRIVATE
         gateway.h
         gateway.cc
-        opcodes.h
+        protocol.h
     )
 
 target_include_directories(AuroraGateway PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 target_link_libraries(AuroraGateway PUBLIC aurora::common Boost::beast)
-target_link_libraries(AuroraGateway PRIVATE nlohmann_json::nlohmann_json)
+target_link_libraries(AuroraGateway PUBLIC nlohmann_json::nlohmann_json)

--- a/src/aurora/gateway/gateway.cc
+++ b/src/aurora/gateway/gateway.cc
@@ -19,7 +19,7 @@
 #include <string>
 #include <utility>
 
-#define ZLIB_SUFFIX "\x00\x00\xff\xff"
+#include "common/assert.h"
 
 namespace aurora {
 namespace gateway {
@@ -89,6 +89,7 @@ void Session::SubscribeTo(uint16_t intents) { intents_ |= intents; }
 void Session::UnsubscribeFrom(uint16_t intents) { intents_ &= ~intents; }
 
 void Session::OnMessage(beast::error_code error, std::size_t bytes_read) {
+#define ZLIB_SUFFIX "\x00\x00\xff\xff"
   AURORA_UNUSED(bytes_read);
 
   OnError(error);
@@ -144,8 +145,7 @@ void Session::OnMessage(beast::error_code error, std::size_t bytes_read) {
       OnHeartbeatAck(data);
       break;
     default:
-      std::cerr << "Invalid opcode received\n";
-      Disconnect(websocket::close_code(4000));
+      AURORA_UNREACHABLE()
   }
 
   // Clean the buffer and continue listening for more messages.
@@ -154,6 +154,7 @@ void Session::OnMessage(beast::error_code error, std::size_t bytes_read) {
     websocket_.async_read(
         buffer_,
         beast::bind_front_handler(&Session::OnMessage, shared_from_this()));
+#undef ZLIB_SUFFIX
 }
 
 template <class WriteHandler>

--- a/src/aurora/gateway/gateway.cc
+++ b/src/aurora/gateway/gateway.cc
@@ -24,7 +24,9 @@ namespace aurora {
 namespace gateway {
 
 Session::Session(net::io_context &io, net::ssl::context &ssl)
-    : resolver_(net::make_strand(io)), websocket_(net::make_strand(io), ssl), io_(io) {}
+    : resolver_(net::make_strand(io)),
+      websocket_(net::make_strand(io), ssl),
+      io_(io) {}
 
 Session::~Session() {
   try {
@@ -95,13 +97,16 @@ void Session::OnMessage(beast::error_code error, std::size_t bytes_read) {
   std::cout << payload << std::endl;
 
   // TODO: Handle the received opcode accordingly.
-
+  //       Maybe do this using a map!
   if (payload["op"] == 10)
     OnHello(payload["d"]["heartbeat_interval"]);
+  else if (payload["op"] == 11)
+    did_ack_heartbeat_ = true;
 
   // Clean the buffer and continue listening for more messages.
   buffer_.clear();
-  //websocket_.async_read(buffer_, beast::bind_front_handler(&Session::OnMessage,
+  // websocket_.async_read(buffer_,
+  // beast::bind_front_handler(&Session::OnMessage,
   //                                                         shared_from_this()));
 }
 
@@ -119,17 +124,26 @@ void Session::OnHello(int heartbeat_interval) {
 }
 
 void Session::SendHeartbeat() {
+  if (!did_ack_heartbeat_) {
+    std::cerr << "Closing zombied connection";
+    Disconnect(websocket::close_code(4000));
+    return;
+  }
   nlohmann::json payload;
   payload["op"] = 1;
   payload["d"] = 251;
   websocket_.async_write(
-      net::buffer(payload.dump()), [this](beast::error_code const &ec,
-                             std::size_t bytes_transferred) { OnError(ec); });
+      net::buffer(payload.dump()),
+      [this](beast::error_code const &ec, std::size_t bytes_transferred) {
+        did_ack_heartbeat_ = false;
+        OnError(ec);
+      });
 }
 void Session::HeartbeatTask() {
-  boost::asio::steady_timer t(io_, boost::asio::chrono::seconds(heartbeat_interval_));
-  while (true) {
-    t.async_wait([this](const boost::system::error_code& error) {
+  boost::asio::steady_timer t(
+      io_, boost::asio::chrono::seconds(heartbeat_interval_));
+  while (websocket_.is_open()) {
+    t.async_wait([this](const boost::system::error_code &error) {
       if (error) {
         OnError(error);
       } else {

--- a/src/aurora/gateway/gateway.cc
+++ b/src/aurora/gateway/gateway.cc
@@ -182,19 +182,11 @@ void Session::SendHeartbeat() {
 }
 
 void Session::Identify() {
-  nlohmann::json payload = R"(
-  {
-    "token": "token_here",
-    "properties": {
-      "$os": "linux",
-      "$browser": "Aurora",
-      "$device": "Aurora"
-    },
-    "intents": 0
-  }
-)"_json;
-  payload["token"] = token_;
-  payload["intents"] = intents_;
+  nlohmann::json payload = {
+      {"token", token_},
+      {"intents", intents_},
+      {"properties",
+       {{"$os", "linux"}, {"$browser", "Aurora"}, {"$device", "Aurora"}}}};
   SendMessage(payload, Opcode::kIdentify,
               [this](beast::error_code const &ec,
                      std::size_t bytes_transferred) { OnError(ec); });

--- a/src/aurora/gateway/gateway.cc
+++ b/src/aurora/gateway/gateway.cc
@@ -24,7 +24,7 @@ namespace aurora {
 namespace gateway {
 
 Session::Session(net::io_context &io, net::ssl::context &ssl)
-    : resolver_(net::make_strand(io)), websocket_(net::make_strand(io), ssl) {}
+    : resolver_(net::make_strand(io)), websocket_(net::make_strand(io), ssl), io_(io) {}
 
 Session::~Session() {
   try {
@@ -96,10 +96,47 @@ void Session::OnMessage(beast::error_code error, std::size_t bytes_read) {
 
   // TODO: Handle the received opcode accordingly.
 
+  if (payload["op"] == 10)
+    OnHello(payload["d"]["heartbeat_interval"]);
+
   // Clean the buffer and continue listening for more messages.
   buffer_.clear();
   //websocket_.async_read(buffer_, beast::bind_front_handler(&Session::OnMessage,
   //                                                         shared_from_this()));
+}
+
+void Session::OnError(beast::error_code error) {
+  if (!error) return;
+  // TODO: Reconnect
+  std::cerr << "Closing connection due to internal error.";
+
+  Disconnect(websocket::close_code(4000));
+}
+
+void Session::OnHello(int heartbeat_interval) {
+  heartbeat_interval_ = heartbeat_interval;
+  HeartbeatTask();
+}
+
+void Session::SendHeartbeat() {
+  nlohmann::json payload;
+  payload["op"] = 1;
+  payload["d"] = 251;
+  websocket_.async_write(
+      net::buffer(payload.dump()), [this](beast::error_code const &ec,
+                             std::size_t bytes_transferred) { OnError(ec); });
+}
+void Session::HeartbeatTask() {
+  boost::asio::steady_timer t(io_, boost::asio::chrono::seconds(heartbeat_interval_));
+  while (true) {
+    t.async_wait([this](const boost::system::error_code& error) {
+      if (error) {
+        OnError(error);
+      } else {
+        SendHeartbeat();
+      }
+    });
+  }
 }
 
 }  // namespace gateway

--- a/src/aurora/gateway/gateway.h
+++ b/src/aurora/gateway/gateway.h
@@ -57,7 +57,7 @@ namespace websocket = beast::websocket;
  */
 class Session : public std::enable_shared_from_this<Session> {
  public:
-  explicit Session(net::io_context& io, net::ssl::context& ssl);
+  explicit Session(net::io_context& io, net::ssl::context& ssl, bool compress = false);
 
   ~Session();
 
@@ -102,6 +102,7 @@ class Session : public std::enable_shared_from_this<Session> {
   int heartbeat_interval_;
   int last_sequence_;
   bool did_ack_heartbeat_ = true;
+  bool compress_;
 
   /**
    * @brief A callback that is dispatched when a message has been received from

--- a/src/aurora/gateway/gateway.h
+++ b/src/aurora/gateway/gateway.h
@@ -80,8 +80,9 @@ class Session : public std::enable_shared_from_this<Session> {
   net::ip::tcp::resolver resolver_;
   websocket::stream<beast::ssl_stream<net::ip::tcp::socket>> websocket_;
   beast::flat_buffer buffer_;
-  boost::asio::io_context &io_;
+  boost::asio::steady_timer heartbeat_timer_;
   int heartbeat_interval_;
+  int last_sequence_;
   bool did_ack_heartbeat_ = true;
 
   /**
@@ -110,14 +111,14 @@ class Session : public std::enable_shared_from_this<Session> {
   void OnHello(int heartbeat_interval);
 
   /**
-   * @brief Send a generic heartbeat payload
-   */
-  void SendHeartbeat();
-
-  /**
    * @brief Automatically sends a heartbeat in regular intervals
    */
   void HeartbeatTask();
+
+  /**
+   * @brief Sends a generic heartbeat payload
+   */
+  void SendHeartbeat();
 };
 
 }  // namespace gateway

--- a/src/aurora/gateway/gateway.h
+++ b/src/aurora/gateway/gateway.h
@@ -84,13 +84,13 @@ class Session : public std::enable_shared_from_this<Session> {
    * @brief Start receiving certain gateway events
    * @param intents Intent(s) category to subscribe to
    */
-  void SubscribeTo(uint16_t intent);
+  void SubscribeTo(uint16_t intents);
 
   /**
    * @brief Stop receiving certain gateway events
    * @param intents Intent(s) category to unsubscribe from
    */
-  void UnsubscribeFrom(uint16_t intent);
+  void UnsubscribeFrom(uint16_t intents);
 
  private:
   // User specific member variables

--- a/src/aurora/gateway/gateway.h
+++ b/src/aurora/gateway/gateway.h
@@ -106,7 +106,7 @@ class Session : public std::enable_shared_from_this<Session> {
   boost::asio::steady_timer heartbeat_timer_;
   int heartbeat_interval_, last_sequence_;
   bool did_ack_heartbeat_ = true, compress_;
-  std::string session_id_;
+  std::string session_id_, hostname_, port_;
 
   /**
    * @brief A callback that is dispatched when a message has been received from

--- a/src/aurora/gateway/gateway.h
+++ b/src/aurora/gateway/gateway.h
@@ -28,10 +28,9 @@
 #include <boost/beast/ssl.hpp>
 #include <boost/beast/websocket.hpp>
 #include <boost/beast/websocket/ssl.hpp>
-#include <nlohmann/json.hpp>
-
-#include <memory>
 #include <functional>
+#include <memory>
+#include <nlohmann/json.hpp>
 
 #include "common/defines.h"
 #include "protocol.h"
@@ -94,9 +93,8 @@ class Session : public std::enable_shared_from_this<Session> {
   void UnsubscribeFrom(uint16_t intent);
 
  private:
-
   // User specific member variables
-  std::uint16_t intents_;
+  std::uint16_t intents_ = 0;
   std::string token_;
 
   // Internal variables
@@ -104,7 +102,7 @@ class Session : public std::enable_shared_from_this<Session> {
   websocket::stream<beast::ssl_stream<net::ip::tcp::socket>> websocket_;
   beast::flat_buffer buffer_;
   boost::asio::steady_timer heartbeat_timer_;
-  int heartbeat_interval_, last_sequence_;
+  int heartbeat_interval_ = 0, last_sequence_ = 0;
   bool did_ack_heartbeat_ = true, compress_;
   std::string session_id_, hostname_, port_;
 
@@ -134,7 +132,7 @@ class Session : public std::enable_shared_from_this<Session> {
    * @param payload The messages payload
    * @param opcode The message opcode
    */
-  void SendMessage(nlohmann::json payload, Opcode opcode);
+  void SendMessage(const nlohmann::json& payload, Opcode opcode);
 
   /**
    * @brief Generic error handler.
@@ -159,7 +157,7 @@ class Session : public std::enable_shared_from_this<Session> {
    *
    * @warning Never call this function manually!
    */
-  void OnReconnect(nlohmann::json data);
+  void OnReconnect(const nlohmann::json& data);
 
   /**
    * @brief A callback that is dispatched if the gateway sends a invalid
@@ -169,7 +167,7 @@ class Session : public std::enable_shared_from_this<Session> {
    *
    * @warning Never call this function manually!
    */
-  void OnInvalidSession(nlohmann::json data);
+  void OnInvalidSession(const nlohmann::json& data);
 
   /**
    * @brief A callback that is dispatched once the gateway sends the initial
@@ -189,7 +187,7 @@ class Session : public std::enable_shared_from_this<Session> {
    *
    * @warning Never call this function manually!
    */
-  void OnHeartbeatAck(nlohmann::json data);
+  void OnHeartbeatAck(const nlohmann::json& data);
 
   /**
    * @brief Automatically sends a heartbeat in regular intervals

--- a/src/aurora/gateway/gateway.h
+++ b/src/aurora/gateway/gateway.h
@@ -80,6 +80,8 @@ class Session : public std::enable_shared_from_this<Session> {
   net::ip::tcp::resolver resolver_;
   websocket::stream<beast::ssl_stream<net::ip::tcp::socket>> websocket_;
   beast::flat_buffer buffer_;
+  boost::asio::io_context &io_;
+  int heartbeat_interval_;
 
   /**
    * @brief A callback that is dispatched when a message has been received from
@@ -90,6 +92,31 @@ class Session : public std::enable_shared_from_this<Session> {
    * @warning Never call this function manually!
    */
   void OnMessage(beast::error_code error, std::size_t bytes_read);
+
+  /**
+   * @brief Generic error handler.
+   */
+  void OnError(beast::error_code error);
+
+  /**
+   * @brief A callback that is dispatched once the gateway sends the initial
+   * hello payload
+   * @param heartbeat_interval Time in ms to wait between sending heartbeat
+   * payloads
+   *
+   * @warning Never call this function manually!
+   */
+  void OnHello(int heartbeat_interval);
+
+  /**
+   * @brief Send a generic heartbeat payload
+   */
+  void SendHeartbeat();
+
+  /**
+   * @brief Automatically sends a heartbeat in regular intervals
+   */
+  void HeartbeatTask() AURORA_NORETURN;
 };
 
 }  // namespace gateway

--- a/src/aurora/gateway/gateway.h
+++ b/src/aurora/gateway/gateway.h
@@ -118,7 +118,7 @@ class Session : public std::enable_shared_from_this<Session> {
 
   /**
    * @brief Sends a message to the gateway using a user specified
-   * handler callback
+   * handler callback. Always returns immediately.
    * @param payload The messages payload
    * @param opcode The message opcode
    * @param handler The handler to be called after the message was sent
@@ -129,6 +129,7 @@ class Session : public std::enable_shared_from_this<Session> {
 
   /**
    * @brief Sends a message to the gateway using a generic handler callback
+   * Always returns immediately.
    * @param payload The messages payload
    * @param opcode The message opcode
    */
@@ -191,6 +192,7 @@ class Session : public std::enable_shared_from_this<Session> {
 
   /**
    * @brief Automatically sends a heartbeat in regular intervals
+   * Always returns immediately.
    */
   void HeartbeatTask();
 

--- a/src/aurora/gateway/gateway.h
+++ b/src/aurora/gateway/gateway.h
@@ -82,6 +82,7 @@ class Session : public std::enable_shared_from_this<Session> {
   beast::flat_buffer buffer_;
   boost::asio::io_context &io_;
   int heartbeat_interval_;
+  bool did_ack_heartbeat_ = true;
 
   /**
    * @brief A callback that is dispatched when a message has been received from
@@ -116,7 +117,7 @@ class Session : public std::enable_shared_from_this<Session> {
   /**
    * @brief Automatically sends a heartbeat in regular intervals
    */
-  void HeartbeatTask() AURORA_NORETURN;
+  void HeartbeatTask();
 };
 
 }  // namespace gateway

--- a/src/aurora/gateway/protocol.h
+++ b/src/aurora/gateway/protocol.h
@@ -14,13 +14,13 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
- * @file opcodes.h
- * @brief Opcodes used by the Discord gateway protocol.
+ * @file protocol.h
+ * @brief Constants used by the Discord gateway protocol.
  * @author Valentin B.
  */
 
-#ifndef AURORA_GATEWAY_OPCODES_H_
-#define AURORA_GATEWAY_OPCODES_H_
+#ifndef AURORA_GATEWAY_PROTOCOL_H_
+#define AURORA_GATEWAY_PROTOCOL_H_
 
 /**
  * Opcodes used for communication with the Discord WebSocket gateway.
@@ -76,4 +76,25 @@ enum class Opcode {
   kStreamSetPaused = 22,
 };
 
-#endif  // AURORA_GATEWAY_OPCODES_H_
+/**
+ * Intents acting like subscriptions to the Discord WebSocket gateway
+ */
+enum Intent : std::uint16_t {
+    GUILDS = (1u << 0u),
+    GUILD_MEMBERS = (1u << 1u),
+    GUILD_BANS = (1u << 2u),
+    GUILD_EMOJIS = (1u << 3u),
+    GUILD_INTEGRATIONS = (1u << 4u),
+    GUILD_WEBHOOKS = (1u << 5u),
+    GUILD_INVITES = (1u << 6u),
+    GUILD_VOICE_STATES = (1u << 7u),
+    GUILD_PRESENCES = (1u << 8u),
+    GUILD_MESSAGES = (1u << 9u),
+    GUILD_MESSAGE_REACTIONS = (1u << 10u),
+    GUILD_MESSAGE_TYPING = (1u << 11u),
+    DIRECT_MESSAGES = (1u << 12u),
+    DIRECT_MESSAGE_REACTIONS = (1u << 13u),
+    DIRECT_MESSAGE_TYPING = (1u << 14u),
+};
+
+#endif  // AURORA_GATEWAY_PROTOCOL_H_

--- a/src/aurora/gateway/protocol.h
+++ b/src/aurora/gateway/protocol.h
@@ -79,7 +79,7 @@ enum class Opcode {
 /**
  * Intents acting like subscriptions to the Discord WebSocket gateway
  */
-enum Intent : std::uint16_t {
+enum class Intent : std::uint16_t {
     GUILDS = (1u << 0u),
     GUILD_MEMBERS = (1u << 1u),
     GUILD_BANS = (1u << 2u),


### PR DESCRIPTION
This PR adds:
- Identifying
- Heartbeats
- Basic event handling and gateway intents
- Basic (untested) resuming
- Structure to handle compressed messages<sup>1</sup>

Stuff to do after the PR is merged:
- Decompress message as needed
- Decode ETF encoded messages
- Call event handlers for gateway events
- Certain reconnecting behaviour as describes in todo's found in the code

<sup>1</sup>If the `compress` argument in the constructor is `true`, the message handler will check every message for a zlib suffix, but won't actually decompress the message.